### PR TITLE
fix: fix typo in credits remaining message

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -104,7 +104,7 @@ export default function Sidebar() {
             {plan !== "UNLIMITED" && (
               <div className="flex flex-col gap-y-2 rounded-lg bg-[#ece5ff] p-3">
                 <p className="text-xs">
-                  {creditLimit[plan]} / {credits} credits remaining
+                  {credits} / {creditLimit[plan]} credits remaining
                 </p>
                 <Progress
                   className="h-1"


### PR DESCRIPTION
![Screenshot 2024-12-08 081328](https://github.com/user-attachments/assets/5e0b59b7-06bc-4c72-b92a-d8ba829a6886)

A small typo in the "... credits remaining" section